### PR TITLE
Update link to GitHub project

### DIFF
--- a/lib/blocks_web/components/layouts/app.html.heex
+++ b/lib/blocks_web/components/layouts/app.html.heex
@@ -8,7 +8,7 @@
       </p>
     </div>
     <div class="text-white">
-      <a href="https://github.com/wowica/explorer" target="_blank"><.github_logo /></a>
+      <a href="https://github.com/wowica/blocks" target="_blank"><.github_logo /></a>
     </div>
   </div>
 </header>
@@ -23,7 +23,7 @@
       </p>
     </div>
     <div class="text-white mb-3">
-      <a href="https://github.com/wowica/explorer" target="_blank"><.github_logo /></a>
+      <a href="https://github.com/wowica/blocks" target="_blank"><.github_logo /></a>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Even though GitHub takes care of redirecting, update link to match new project name.