### PR TITLE
Add npm install as part of mix setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,9 @@ A simple Cardano Blockchain explorer written in [Phoenix LiveView](https://www.p
 ## Running the application
 
   * Clone this repository
-  * Run `npm install --prefix assets` to install the dependencies for the frontend
   * Run `mix setup` to install dependencies and build the application
   * Populate the `OGMIOS_URL` environment variable - if you don't have one, you can use a managed instance from [Demeter.run](https://demeter.run)
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-## Running in Docker
-
-A Docker compose file is available to allow running the application using the following command:
-
-```
-OGMIOS_URL="..." docker-compose up
-```

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Blocks.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get", "assets.setup", "assets.build"],
+      setup: ["deps.get", "cmd npm install --prefix assets", "assets.setup", "assets.build"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
       "assets.build": ["tailwind default", "esbuild default"],
       "assets.deploy": ["tailwind default --minify", "esbuild default --minify", "phx.digest"]


### PR DESCRIPTION
Remove docker instructions because they are particular to prod deployment and currently tied to using a custom domain.